### PR TITLE
Use uint16_t for showmsgXY() colour

### DIFF
--- a/src/EX-Fast_Clock.cpp
+++ b/src/EX-Fast_Clock.cpp
@@ -60,8 +60,8 @@ TouchScreen ts = TouchScreen(XP, YP, XM, YM, 300);
 #include <Fonts/Arial48pt7b.h>
 #include <Fonts/Arial9pt7b.h>
 
-//void showmsgXY(byte x, byte y, byte sz, char colour, const char *msg)
-void showmsgXY(byte x, byte y, byte sz, char colour, char *msg)
+//void showmsgXY(byte x, byte y, byte sz, uint16_t colour, const char *msg)
+void showmsgXY(byte x, byte y, byte sz, uint16_t colour, char *msg)
 {
     tft.setFont();
     tft.setFont(&Arial9pt7b);


### PR DESCRIPTION
Aligns with Adafruit_GFX setTextColor() that is being used here.

https://github.com/DCC-EX/EX-FastClock/blob/b20fa5fd8ac863dec4689ff0991d7bccab7c8b7e/.pio/libdeps/uno/Adafruit%20GFX%20Library/Adafruit_GFX.h#L141

Resolves warning:

```
src/EX-Fast_Clock.h:44:17: warning: overflow in conversion from ‘unsigned int’ to ‘char’ changes value from ‘65504’ to ‘-32’ [-Woverflow]
   44 | #define YELLOW  0xFFE0
      |                 ^~~~~~
src/EX-Fast_Clock.cpp:269:31: note: in expansion of macro ‘YELLOW’
  269 |         showmsgXY(55, 160, 2, YELLOW, "PAUSED");
```